### PR TITLE
Add OpenAPI helper script and sample account request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,16 +5,21 @@ This repository contains tools for exploring the Firefly III OpenAPI specificati
 ## openapi_helper.py
 - `python openapi_helper.py` lists all endpoints in `firefly-iii-6.3.0-v1.yaml`.
 - `python openapi_helper.py <path>` prints the full, `$ref`-resolved details for the specified endpoint.
-- With `BASE_URL` and `ACCESS_TOKEN` set, `python openapi_helper.py <path> --request` performs a GET request against the demo API and prints the JSON response. Redirect output to a file to save it.
+- With `BASE_URL` and `ACCESS_TOKEN` set, `python openapi_helper.py <path> --request` performs a request against the demo API. The helper prefixes the path with `/api` and consults the OpenAPI spec to choose `Accept` and `Content-Type` headers. Use `--accept` or `--content-type` to override the spec when multiple media types are available, and `--method` to select an HTTP method.
+- The helper censors any occurrence of `BASE_URL` or `ACCESS_TOKEN` in its output so these values never appear in logs or files.
 
 ## Demo environment
 The variables `BASE_URL` and `ACCESS_TOKEN` point to a Firefly III demo system. The system contains no valuable data and can be changed freely.
 
 Example:
 ```bash
-export BASE_URL="https://demo.firefly-iii.org"
-export ACCESS_TOKEN="demo_token"
-python openapi_helper.py /api/v1/accounts --request > accounts.json
+# Environment already provides BASE_URL and ACCESS_TOKEN
+curl -X GET --location "$BASE_URL/api/v1/accounts" \
+    -H "Accept: application/vnd.api+json" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -o accounts.json
 ```
 
-The above command writes the list of accounts to `accounts.json`.
+The above command writes the list of accounts to `accounts.json`. You can also
+use `python openapi_helper.py /v1/accounts --request` to fetch the same data.

--- a/accounts.json
+++ b/accounts.json
@@ -1,1 +1,77 @@
-{"status": 403, "body": "<!DOCTYPE html><html lang=\"en-US\"><head><title>Just a moment...</title><meta http-equiv=\"Content-Typ"}
+{
+  "data": [
+    {
+      "type": "accounts",
+      "id": "1",
+      "attributes": {
+        "created_at": "2025-09-10T22:14:20+02:00",
+        "updated_at": "2025-09-10T22:14:20+02:00",
+        "active": true,
+        "order": 1,
+        "name": "Main account",
+        "type": "asset",
+        "account_role": "defaultAsset",
+        "object_group_id": null,
+        "object_group_order": null,
+        "object_group_title": null,
+        "object_has_currency_setting": true,
+        "currency_id": "1",
+        "currency_name": "Euro",
+        "currency_code": "EUR",
+        "currency_symbol": "\u20ac",
+        "currency_decimal_places": 2,
+        "primary_currency_id": "1",
+        "primary_currency_name": "Euro",
+        "primary_currency_code": "EUR",
+        "primary_currency_symbol": "\u20ac",
+        "primary_currency_decimal_places": 2,
+        "current_balance": "0",
+        "pc_current_balance": null,
+        "opening_balance": null,
+        "pc_opening_balance": null,
+        "virtual_balance": "0",
+        "pc_virtual_balance": null,
+        "debt_amount": null,
+        "pc_debt_amount": null,
+        "current_balance_date": "2025-09-11T23:59:59+02:00",
+        "notes": null,
+        "monthly_payment_date": null,
+        "credit_card_type": null,
+        "account_number": null,
+        "iban": null,
+        "bic": null,
+        "opening_balance_date": null,
+        "liability_type": null,
+        "liability_direction": null,
+        "interest": null,
+        "interest_period": null,
+        "include_net_worth": true,
+        "longitude": null,
+        "latitude": null,
+        "zoom_level": null,
+        "last_activity": null
+      },
+      "links": {
+        "self": "<BASE_URL>/api/v1/accounts/1",
+        "0": {
+          "rel": "self",
+          "uri": "/accounts/1"
+        }
+      }
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "total": 1,
+      "count": 1,
+      "per_page": 50,
+      "current_page": 1,
+      "total_pages": 1
+    }
+  },
+  "links": {
+    "self": "<BASE_URL>/api/v1/accounts?limit=50&type=all&page=1",
+    "first": "<BASE_URL>/api/v1/accounts?limit=50&type=all&page=1",
+    "last": "<BASE_URL>/api/v1/accounts?limit=50&type=all&page=1"
+  }
+}

--- a/openapi_helper.py
+++ b/openapi_helper.py
@@ -4,12 +4,13 @@
 Usage:
   python openapi_helper.py                # list all endpoints
   python openapi_helper.py <path>         # show details for a single endpoint
-  python openapi_helper.py <path> --request  # perform GET request to the endpoint using BASE_URL and ACCESS_TOKEN
+  python openapi_helper.py <path> --request  # perform request to the endpoint using BASE_URL and ACCESS_TOKEN
 """
 import argparse
 import os
 import sys
 import json
+from typing import Optional, Union
 from pprint import pprint
 
 import requests
@@ -36,33 +37,102 @@ def show_endpoint(spec, path):
     pprint(info)
 
 
-def fetch_endpoint(path):
+def _choose_media_type(content: dict) -> Optional[str]:
+    if not content:
+        return None
+    for media_type in content:
+        if "json" in media_type:
+            return media_type
+    return next(iter(content))
+
+
+def _censor(value: Union[str, bytes], base_url: str, token: str) -> Union[str, bytes]:
+    """Replace any occurrence of BASE_URL or ACCESS_TOKEN with placeholders."""
+    if isinstance(value, bytes):
+        if base_url:
+            value = value.replace(base_url.encode(), b"<BASE_URL>")
+        if token:
+            value = value.replace(token.encode(), b"<ACCESS_TOKEN>")
+    else:
+        if base_url:
+            value = value.replace(base_url, "<BASE_URL>")
+        if token:
+            value = value.replace(token, "<ACCESS_TOKEN>")
+    return value
+
+
+def fetch_endpoint(spec, path, method="get", accept_override=None, content_override=None):
     base_url = os.environ.get("BASE_URL")
     token = os.environ.get("ACCESS_TOKEN")
     if not base_url or not token:
         raise RuntimeError("BASE_URL and ACCESS_TOKEN environment variables must be set")
-    url = f"{base_url.rstrip('/')}{path}"
+    path_item = spec.get("paths", {}).get(path)
+    if path_item is None:
+        raise RuntimeError(f"Endpoint {path} not found in spec")
+    op = path_item.get(method.lower())
+    if op is None:
+        raise RuntimeError(f"Method {method} not supported for {path}")
+
+    accept = accept_override
+    if accept is None:
+        responses = op.get("responses", {})
+        for code in sorted(responses):
+            if str(code).startswith("2"):
+                content = responses[code].get("content", {})
+                accept = _choose_media_type(content)
+                break
+
+    content_type = content_override
+    if content_type is None:
+        request_body = op.get("requestBody")
+        if request_body:
+            content = request_body.get("content", {})
+            content_type = _choose_media_type(content)
+
+    url = f"{base_url.rstrip('/')}/api{path}"
     headers = {"Authorization": f"Bearer {token}"}
-    response = requests.get(url, headers=headers)
+    if accept:
+        headers["Accept"] = accept
+    if content_type and method.lower() in {"post", "put", "patch"}:
+        headers["Content-Type"] = content_type
+
+    response = requests.request(method.upper(), url, headers=headers)
     response.raise_for_status()
-    return response.json()
+    return response
 
 
 def main(argv):
     parser = argparse.ArgumentParser(description="Inspect Firefly III OpenAPI spec")
     parser.add_argument("path", nargs="?", help="Endpoint path to inspect")
-    parser.add_argument("--request", action="store_true", help="Perform GET request to the given path using BASE_URL and ACCESS_TOKEN")
+    parser.add_argument("--request", action="store_true", help="Perform request to the given path using BASE_URL and ACCESS_TOKEN")
+    parser.add_argument("--method", default="get", help="HTTP method for --request")
+    parser.add_argument("--accept", help="Override Accept header")
+    parser.add_argument("--content-type", help="Override Content-Type header")
     args = parser.parse_args(argv)
 
     spec = load_spec()
 
     if args.path is None:
         list_endpoints(spec)
+    elif args.request:
+        resp = fetch_endpoint(
+            spec,
+            args.path,
+            method=args.method,
+            accept_override=args.accept,
+            content_override=args.content_type,
+        )
+        ctype = resp.headers.get("Content-Type", "")
+        base_url = os.environ.get("BASE_URL", "")
+        token = os.environ.get("ACCESS_TOKEN", "")
+        if "json" in ctype:
+            text = json.dumps(resp.json(), indent=2)
+            print(_censor(text, base_url, token))
+        else:
+            content = _censor(resp.content, base_url, token)
+            sys.stdout.buffer.write(content)
     else:
         show_endpoint(spec, args.path)
-        if args.request:
-            data = fetch_endpoint(args.path)
-            print(json.dumps(data, indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `openapi_helper.py` to list endpoints from the Firefly III OpenAPI spec and fetch endpoint data using env vars
- document usage and demo environment in `AGENTS.md`
- example `accounts.json` from attempting to call the accounts endpoint

## Testing
- `python openapi_helper.py | grep '/v1/accounts' | head -n 5`
- `BASE_URL=https://demo.firefly-iii.org/api ACCESS_TOKEN=demo python - <<'PY'
import os, requests, json
url = f"{os.environ['BASE_URL'].rstrip('/')}/v1/accounts"
headers={"Authorization": f"Bearer {os.environ['ACCESS_TOKEN']}"}
resp = requests.get(url, headers=headers)
open('accounts.json','w').write(json.dumps({'status': resp.status_code, 'body': resp.text[:100]}))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c1e459afb08332855f6f0ed9e57c25