### PR TITLE
Display network errors and request network access permissions

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+<uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
@@ -50,6 +50,16 @@ fun App() {
 				.fillMaxSize()
 				.padding(16.dp),
 		) {
+			if (viewModel.errorMessage != null) {
+				Text(
+					viewModel.errorMessage!!,
+					modifier = Modifier
+						.fillMaxWidth()
+						.background(MaterialTheme.colorScheme.errorContainer)
+						.padding(8.dp),
+					color = MaterialTheme.colorScheme.onErrorContainer,
+				)
+			}
 			ExposedDropdownMenuBox(
 				expanded = viewModel.expandedSource,
 				onExpandedChange = { viewModel.expandedSource = !viewModel.expandedSource },

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
@@ -16,9 +16,15 @@ class MainViewModel(private val client: HttpClient) {
 	var expandedTarget by mutableStateOf(false)
 	var selectedSource by mutableStateOf<Account?>(null)
 	var selectedTarget by mutableStateOf<Account?>(null)
+	var errorMessage by mutableStateOf<String?>(null)
 
 	suspend fun loadAccounts() {
-		accounts = fetchAccounts(client)
+		try {
+			accounts = fetchAccounts(client)
+			errorMessage = null
+		} catch (t: Throwable) {
+			errorMessage = "Failed to reach server"
+		}
 	}
 
 	fun onSourceTextChange(text: String) {
@@ -36,8 +42,17 @@ class MainViewModel(private val client: HttpClient) {
 	suspend fun save() {
 		val src = selectedSource
 		if (src != null && amount.isNotBlank() && description.isNotBlank()) {
-			createTransaction(client, src, targetText, selectedTarget, description, amount)
+			try {
+				createTransaction(client, src, targetText, selectedTarget, description, amount)
+				errorMessage = null
+			} catch (t: Throwable) {
+				errorMessage = "Failed to reach server"
+			}
 		}
+	}
+
+	fun clearError() {
+		errorMessage = null
 	}
 
 	fun clear() {

--- a/composeApp/src/commonTest/kotlin/de/lehrbaum/firefly/MainViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/de/lehrbaum/firefly/MainViewModelTest.kt
@@ -6,6 +6,7 @@ import io.ktor.client.engine.mock.respondOk
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
 
 class MainViewModelTest {
 	@Test
@@ -25,4 +26,13 @@ class MainViewModelTest {
 		assertNull(viewModel.selectedSource)
 		assertNull(viewModel.selectedTarget)
 	}
+
+	@Test
+	fun loadAccounts_setsErrorMessage_onFailure() =
+		runTest {
+			val client = HttpClient(MockEngine { throw RuntimeException("network") })
+			val viewModel = MainViewModel(client)
+			viewModel.loadAccounts()
+			assertEquals("Failed to reach server", viewModel.errorMessage)
+		}
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -2,7 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
+<key>CADisableMinimumFrameDurationOnPhone</key>
+<true/>
+<key>NSAppTransportSecurity</key>
+<dict>
+<key>NSAllowsArbitraryLoads</key>
+<true/>
+</dict>
 </dict>
 </plist>
+


### PR DESCRIPTION
## Summary
- show an error banner when requests to Firefly fail
- request network permissions on Android and allow arbitrary loads on iOS
- test MainViewModel error handling

## Testing
- `./gradlew ktlintFormat`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c3fd78f51c83329b3d3bab24227e4e