### PR TITLE
Prioritize cash accounts in source account suggestions

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
@@ -72,7 +72,11 @@ fun App() {
 					label = { Text("Source account") },
 				)
 				val suggestions =
-					viewModel.accounts.filter { it.name.contains(viewModel.sourceText, true) && it.type == "asset" }
+					viewModel.accounts
+						.filter {
+							it.name.contains(viewModel.sourceText, true) &&
+								(it.type == "asset" || it.type == "cash")
+						}.sortedWith(compareBy({ it.type != "cash" }, { it.name.lowercase() }))
 				DropdownMenu(
 					expanded = viewModel.expandedSource,
 					onDismissRequest = { viewModel.expandedSource = false },


### PR DESCRIPTION
## Summary
- Show cash accounts before other assets in the source account autocomplete
- Alphabetically sort suggestions after cash accounts

## Testing
- `./gradlew ktlintFormat`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c59fb2dd348332b3b269bed07443ca