### PR TITLE
Add transaction date-time selection

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -45,7 +45,6 @@ kotlin {
 			implementation(libs.ktor.client.core)
 			implementation(libs.ktor.client.contentNegotiation)
 			implementation(libs.ktor.serialization.kotlinxJson)
-			implementation(libs.kotlinx.datetime)
 			implementation(libs.napier)
 		}
 		iosArm64Main.dependencies {

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
@@ -7,7 +7,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -16,22 +19,33 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 @Preview
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
 fun App() {
 	MaterialTheme {
 		val client = remember {
@@ -44,6 +58,9 @@ fun App() {
 		val viewModel = remember { MainViewModel(client) }
 		LaunchedEffect(Unit) { viewModel.loadAccounts() }
 		val scope = rememberCoroutineScope()
+		var showDatePicker by remember { mutableStateOf(false) }
+		var showTimePicker by remember { mutableStateOf(false) }
+		var pendingDateMillis by remember { mutableStateOf<Long?>(null) }
 		Column(
 			modifier = Modifier
 				.background(MaterialTheme.colorScheme.primaryContainer)
@@ -128,6 +145,66 @@ fun App() {
 				onValueChange = { viewModel.amount = it },
 				label = { Text("Amount") },
 			)
+			OutlinedTextField(
+				modifier = Modifier.fillMaxWidth(),
+				value = viewModel.dateTime.toString(),
+				onValueChange = {},
+				label = { Text("Date & Time") },
+				readOnly = true,
+			)
+			Button(onClick = { showDatePicker = true }) { Text("Set Date & Time") }
+			if (showDatePicker) {
+				val datePickerState = rememberDatePickerState(initialSelectedDateMillis = viewModel.dateTime.toEpochMilliseconds())
+				DatePickerDialog(
+					onDismissRequest = { showDatePicker = false },
+					confirmButton = {
+						TextButton(
+							onClick = {
+								val millis = datePickerState.selectedDateMillis
+								if (millis != null) {
+									pendingDateMillis = millis
+									showDatePicker = false
+									showTimePicker = true
+								} else {
+									showDatePicker = false
+								}
+							},
+						) { Text("OK") }
+					},
+					dismissButton = {
+						TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+					},
+				) {
+					DatePicker(state = datePickerState)
+				}
+			}
+			if (showTimePicker) {
+				val hour = ((viewModel.dateTime.toEpochMilliseconds() % (24L * 60 * 60 * 1000)) / (60 * 60 * 1000)).toInt()
+				val minute = ((viewModel.dateTime.toEpochMilliseconds() % (60 * 60 * 1000)) / (60 * 1000)).toInt()
+				val timePickerState = rememberTimePickerState(initialHour = hour, initialMinute = minute)
+				AlertDialog(
+					onDismissRequest = { showTimePicker = false },
+					confirmButton = {
+						TextButton(
+							onClick = {
+								val base = pendingDateMillis ?: viewModel.dateTime.toEpochMilliseconds()
+								val newInstant = Instant
+									.fromEpochMilliseconds(base)
+									.plus(timePickerState.hour.hours)
+									.plus(timePickerState.minute.minutes)
+								viewModel.onDateTimeChange(newInstant)
+								showTimePicker = false
+							},
+						) { Text("OK") }
+					},
+					dismissButton = {
+						TextButton(onClick = { showTimePicker = false }) { Text("Cancel") }
+					},
+					text = {
+						TimePicker(state = timePickerState)
+					},
+				)
+			}
 			Row(modifier = Modifier.fillMaxWidth()) {
 				Button(onClick = { scope.launch { viewModel.save() } }) { Text("Save") }
 				Button(onClick = { viewModel.clear() }) { Text("Clear") }

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
@@ -5,8 +5,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import io.github.aakira.napier.Napier
 import io.ktor.client.HttpClient
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import kotlinx.coroutines.CancellationException
 
+@OptIn(ExperimentalTime::class)
 class MainViewModel(private val client: HttpClient) {
 	var accounts by mutableStateOf<List<Account>>(emptyList())
 		private set
@@ -19,6 +23,7 @@ class MainViewModel(private val client: HttpClient) {
 	var selectedSource by mutableStateOf<Account?>(null)
 	var selectedTarget by mutableStateOf<Account?>(null)
 	var errorMessage by mutableStateOf<String?>(null)
+	var dateTime by mutableStateOf(Clock.System.now())
 
 	suspend fun loadAccounts() {
 		runNetworkCall {
@@ -49,6 +54,7 @@ class MainViewModel(private val client: HttpClient) {
 					selectedTarget,
 					description,
 					amount,
+					dateTime,
 				)
 			}
 		}
@@ -79,5 +85,10 @@ class MainViewModel(private val client: HttpClient) {
 		amount = ""
 		selectedSource = null
 		selectedTarget = null
+		dateTime = Clock.System.now()
+	}
+
+	fun onDateTimeChange(newDateTime: Instant) {
+		dateTime = newDateTime
 	}
 }

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/TransactionsApi.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/TransactionsApi.kt
@@ -8,7 +8,6 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
-import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.serialization.SerialName
@@ -38,9 +37,9 @@ suspend fun createTransaction(
 	target: Account?,
 	description: String,
 	amount: String,
+	dateTime: Instant,
 ) {
 	Napier.i("Creating transaction $description $amount from ${source.name} to ${target?.name ?: targetText}")
-	val now: Instant = Clock.System.now()
 	val type = when {
 		target != null && target.type == "asset" -> "transfer"
 		target != null && target.type == "revenue" -> "deposit"
@@ -48,7 +47,7 @@ suspend fun createTransaction(
 	}
 	val split = TransactionSplitRequest(
 		type = type,
-		date = now.toString(),
+		date = dateTime.toString(),
 		amount = amount,
 		description = description,
 		sourceId = source.id,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ kotlin = "2.2.20"
 ktlint = "13.1.0"
 ktor = "3.3.0"
 kotlinx-coroutines = "1.10.2"
-kotlinx-datetime = "0.7.1-0.6.x-compat"
 napier = "2.7.1"
 
 
@@ -37,7 +36,6 @@ ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotia
 ktor-serialization-kotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 
 [plugins]


### PR DESCRIPTION
## Summary
- allow picking custom transaction date and time
- migrate to kotlin.time and drop deprecated kotlinx.datetime

## Testing
- `./gradlew ktlintFormat`
- `./gradlew build --warning-mode all`


------
https://chatgpt.com/codex/tasks/task_e_68c59f2609448332b162676f9a24bd59