### PR TITLE
Fix missing Content-Type when creating transactions

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/TransactionsApi.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/TransactionsApi.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -58,6 +59,7 @@ suspend fun createTransaction(
 	client.post("${BuildKonfig.BASE_URL}/api/v1/transactions") {
 		header(HttpHeaders.Authorization, "Bearer ${BuildKonfig.ACCESS_TOKEN}")
 		accept(ContentType.parse("application/vnd.api+json"))
+		contentType(ContentType.Application.Json)
 		setBody(TransactionRequest(listOf(split)))
 	}
 	Napier.d("Transaction created")

--- a/composeApp/src/commonTest/kotlin/de/lehrbaum/firefly/TransactionsApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/de/lehrbaum/firefly/TransactionsApiTest.kt
@@ -1,0 +1,33 @@
+package de.lehrbaum.firefly
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondOk
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.content.OutgoingContent
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+class TransactionsApiTest {
+	@Test
+	fun createTransaction_setsJsonContentType() =
+		runTest {
+			var recordedContentType: String? = null
+			val engine = MockEngine { request ->
+				val content = request.body as OutgoingContent
+				recordedContentType = content.contentType?.toString()
+				respondOk()
+			}
+			val client = HttpClient(engine) {
+				install(ContentNegotiation) {
+					json(Json { ignoreUnknownKeys = true })
+				}
+			}
+			val source = Account("1", "Source", "asset")
+			createTransaction(client, source, "Target", null, "desc", "1")
+			assertEquals("application/json", recordedContentType)
+		}
+}


### PR DESCRIPTION
## Summary
- set JSON Content-Type when posting transactions
- add unit test for transaction Content-Type

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c6a4ac38dc83329a29419819c9471c