### PR TITLE
Fix TransactionsApiTest missing date and experimental opt-in

### DIFF
--- a/composeApp/src/commonTest/kotlin/de/lehrbaum/firefly/TransactionsApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/de/lehrbaum/firefly/TransactionsApiTest.kt
@@ -8,10 +8,13 @@ import io.ktor.http.content.OutgoingContent
 import io.ktor.serialization.kotlinx.json.json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 
 class TransactionsApiTest {
+	@OptIn(ExperimentalTime::class)
 	@Test
 	fun createTransaction_setsJsonContentType() =
 		runTest {
@@ -27,7 +30,15 @@ class TransactionsApiTest {
 				}
 			}
 			val source = Account("1", "Source", "asset")
-			createTransaction(client, source, "Target", null, "desc", "1")
+			createTransaction(
+				client,
+				source,
+				"Target",
+				null,
+				"desc",
+				"1",
+				Instant.fromEpochMilliseconds(0),
+			)
 			assertEquals("application/json", recordedContentType)
 		}
 }


### PR DESCRIPTION
## Summary
- opt-in to `ExperimentalTime` and provide a `Instant` date when calling `createTransaction` in `TransactionsApiTest`

## Testing
- `./gradlew ktlintFormat`
- `./gradlew composeApp:compileTestKotlinIosSimulatorArm64`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c6b79647e883329000abd43c32423f