### PR TITLE
Add optional tag autocomplete field

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
@@ -77,6 +77,7 @@ fun App() {
 			AutocompleteTextField(field = viewModel.sourceField, label = "Source account")
 			AutocompleteTextField(field = viewModel.targetField, label = "Target account")
 			AutocompleteTextField(field = viewModel.descriptionField, label = "Description")
+			AutocompleteTextField(field = viewModel.tagField, label = "Tag (optional)")
 			OutlinedTextField(
 				modifier = Modifier.fillMaxWidth(),
 				value = viewModel.amount,

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
@@ -28,6 +28,7 @@ class MainViewModel(
 	)
 	val targetField = AutocompleteField(scope, autocompleteApi::accounts, Account::name)
 	val descriptionField = AutocompleteField(scope, { q -> autocompleteApi.transactions(q).map { it.description } }, { it })
+	val tagField = AutocompleteField(scope, autocompleteApi::tags, TagSuggestion::tag)
 
 	var amount by mutableStateOf("")
 	var errorMessage by mutableStateOf<String?>(null)
@@ -54,6 +55,7 @@ class MainViewModel(
 					targetField.selected,
 					descriptionField.selectedText,
 					amount,
+					tagField.selectedText.trim().takeIf { it.isNotEmpty() },
 					dateTime.toInstant(TimeZone.currentSystemDefault()),
 				)
 			}
@@ -84,6 +86,7 @@ class MainViewModel(
 		sourceField.clear()
 		targetField.clear()
 		descriptionField.clear()
+		tagField.clear()
 		amount = ""
 		dateTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
 	}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
@@ -28,7 +28,7 @@ class MainViewModel(
 	)
 	val targetField = AutocompleteField(scope, autocompleteApi::accounts, Account::name)
 	val descriptionField = AutocompleteField(scope, { q -> autocompleteApi.transactions(q).map { it.description } }, { it })
-	val tagField = AutocompleteField(scope, autocompleteApi::tags, TagSuggestion::tag)
+	val tagField = AutocompleteField(scope, autocompleteApi::tags, TagSuggestion::name)
 
 	var amount by mutableStateOf("")
 	var errorMessage by mutableStateOf<String?>(null)
@@ -55,7 +55,8 @@ class MainViewModel(
 					targetField.selected,
 					descriptionField.selectedText,
 					amount,
-					tagField.selectedText.trim().takeIf { it.isNotEmpty() },
+					tagField.selected?.tag
+						?: tagField.text.trim().takeIf { it.isNotEmpty() },
 					dateTime.toInstant(TimeZone.currentSystemDefault()),
 				)
 			}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/TransactionsApi.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/TransactionsApi.kt
@@ -23,6 +23,7 @@ private data class TransactionSplitRequest(
 	@SerialName("source_id") val sourceId: String,
 	@SerialName("destination_id") val destinationId: String? = null,
 	@SerialName("destination_name") val destinationName: String? = null,
+	val tags: List<String>? = null,
 )
 
 @Serializable
@@ -39,6 +40,7 @@ suspend fun createTransaction(
 	target: Account?,
 	description: String,
 	amount: String,
+	tag: String?,
 	date: Instant,
 ) {
 	Napier.i("Creating transaction $description $amount from ${source.name} to ${target?.name ?: targetText}")
@@ -51,6 +53,7 @@ suspend fun createTransaction(
 		sourceId = source.id,
 		destinationId = target?.id,
 		destinationName = if (target == null) targetText else null,
+		tags = tag?.let(::listOf),
 	)
 	client.post("${BuildKonfig.BASE_URL}/api/v1/transactions") {
 		header(HttpHeaders.Authorization, "Bearer ${BuildKonfig.ACCESS_TOKEN}")


### PR DESCRIPTION
## Summary
- add an optional tag autocomplete input to the transaction form and view model
- extend the autocomplete API to retrieve tag suggestions
- include the selected tag when creating transactions via the API

## Testing
- ./gradlew --console=plain ktlintFormat
- ./gradlew --console=plain composeApp:compileCommonMainKotlinMetadata

------
https://chatgpt.com/codex/tasks/task_e_68cdbcafe1488332a26c991887cc16de