### PR TITLE
Add checkAgentsEnvironment Gradle task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,4 @@ use `python openapi_helper.py /v1/accounts --request` to fetch the same data.
 - Use `kotlin.test` for unit tests in shared code.
 - Use the Compose UI Test toolkit for UI testing.
 - Use `kotlinx.coroutines.test` (e.g. `runTest`) for coroutine-based code.
+- Run `./gradlew checkAgentsEnvironment --console=plain` before committing.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,3 +21,14 @@ allprojects {
 		}
 	}
 }
+
+tasks.register("checkAgentsEnvironment") {
+	group = "verification"
+	description = "Runs all tests that are expected to pass in the agent environment"
+	dependsOn(
+		":composeApp:testDebugUnitTest",
+		":composeApp:testReleaseUnitTest",
+	)
+	dependsOn("ktlintCheck")
+	dependsOn(subprojects.map { "${it.path}:ktlintCheck" })
+}


### PR DESCRIPTION
## Summary
- add a checkAgentsEnvironment task that runs the Android unit tests and ktlint checks expected to pass on agents

## Testing
- `./gradlew checkAgentsEnvironment --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68cdc1318cac8332a2957cb068ebd592