### PR TITLE
Parse amount input using locale

### DIFF
--- a/composeApp/src/androidMain/kotlin/de/lehrbaum/firefly/LocaleSeparators.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/lehrbaum/firefly/LocaleSeparators.android.kt
@@ -1,0 +1,16 @@
+package de.lehrbaum.firefly
+
+import java.text.DecimalFormatSymbols
+import java.util.Locale
+
+internal actual fun localeSeparators(): LocaleSeparators {
+	val symbols = DecimalFormatSymbols.getInstance(Locale.getDefault())
+	val groupingSeparators = buildSet {
+		val grouping = symbols.groupingSeparator
+		if (grouping != Char.MIN_VALUE) add(grouping)
+	}
+	return LocaleSeparators(
+		decimalSeparator = symbols.decimalSeparator,
+		groupingSeparators = groupingSeparators,
+	)
+}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/AmountParser.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/AmountParser.kt
@@ -1,0 +1,99 @@
+package de.lehrbaum.firefly
+
+internal data class LocaleSeparators(
+	val decimalSeparator: Char,
+	val groupingSeparators: Set<Char>,
+)
+
+internal expect fun localeSeparators(): LocaleSeparators
+
+internal object AmountParser {
+	private val additionalGroupingSeparators = setOf(' ', '\u00A0', '\u202F', Char(0x27))
+
+	fun parseToApiFormat(rawAmount: String, separators: LocaleSeparators = localeSeparators()): String {
+		val trimmed = rawAmount.trim()
+		if (trimmed.isEmpty()) return trimmed
+
+		val localeDecimal = separators.decimalSeparator
+		val groupingSeparators = (separators.groupingSeparators + additionalGroupingSeparators)
+			.filter { it != localeDecimal }
+			.toSet()
+
+		val detectedDecimal = detectDecimalSeparator(trimmed, localeDecimal, groupingSeparators)
+
+		val cleaned = buildString(trimmed.length) {
+			for (character in trimmed) {
+				if (groupingSeparators.contains(character) && character != detectedDecimal) continue
+				append(character)
+			}
+		}
+
+		val replacedDecimal = when {
+			detectedDecimal == null || detectedDecimal == '.' -> cleaned
+			else -> cleaned.replace(detectedDecimal, '.')
+		}
+
+		val normalized = StringBuilder(replacedDecimal.length)
+		var decimalAdded = false
+		for (character in replacedDecimal) {
+			when {
+				character.isDigit() -> normalized.append(character)
+				character == '-' && normalized.isEmpty() -> normalized.append(character)
+				character == '+' && normalized.isEmpty() -> {} // Ignore leading plus signs
+				character == '.' && !decimalAdded -> {
+					if (normalized.isEmpty() || (normalized.length == 1 && normalized[0] == '-')) {
+						normalized.append('0')
+					}
+					normalized.append('.')
+					decimalAdded = true
+				}
+			}
+		}
+		val result = normalized.toString()
+		return if (result.isNotEmpty() && result != "-") result else trimmed
+	}
+
+	private fun detectDecimalSeparator(
+		value: String,
+		localeDecimal: Char,
+		groupingSeparators: Set<Char>,
+	): Char? {
+		val localeIndex = value.lastIndexOf(localeDecimal)
+		if (localeIndex >= 0 && digitsAfter(value, localeIndex) > 0) {
+			return localeDecimal
+		}
+
+		val lastDotIndex = value.lastIndexOf('.')
+		val lastCommaIndex = value.lastIndexOf(',')
+
+		if (lastDotIndex >= 0 && lastCommaIndex >= 0) {
+			val candidateIndex = maxOf(lastDotIndex, lastCommaIndex)
+			val candidate = value[candidateIndex]
+			if (digitsAfter(value, candidateIndex) > 0 && candidate !in groupingSeparators) {
+				return candidate
+			}
+		}
+
+		if (lastDotIndex >= 0) {
+			val digitsAfterDot = digitsAfter(value, lastDotIndex)
+			if (digitsAfterDot > 0 && '.' !in groupingSeparators) {
+				return '.'
+			}
+		}
+
+		if (lastCommaIndex >= 0) {
+			val digitsAfterComma = digitsAfter(value, lastCommaIndex)
+			if (digitsAfterComma > 0 && ',' !in groupingSeparators) {
+				return ','
+			}
+
+			if (lastCommaIndex >= 0 && digitsAfterComma in 1..2) {
+				return ','
+			}
+		}
+
+		return null
+	}
+
+	private fun digitsAfter(value: String, index: Int): Int = value.substring(index + 1).count { it.isDigit() }
+}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
@@ -47,13 +47,14 @@ class MainViewModel(
 		val src = sourceField.selected
 		if (src != null && amount.isNotBlank() && descriptionField.selectedText.isNotBlank()) {
 			runNetworkCall {
+				val normalizedAmount = AmountParser.parseToApiFormat(amount)
 				createTransaction(
 					client,
 					src,
 					targetField.selectedText,
 					targetField.selected,
 					descriptionField.selectedText,
-					amount,
+					normalizedAmount,
 					dateTime.toInstant(TimeZone.currentSystemDefault()),
 				)
 			}

--- a/composeApp/src/commonTest/kotlin/de/lehrbaum/firefly/AmountParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/de/lehrbaum/firefly/AmountParserTest.kt
@@ -1,0 +1,58 @@
+package de.lehrbaum.firefly
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AmountParserTest {
+	private val germanSeparators = LocaleSeparators(decimalSeparator = ',', groupingSeparators = setOf('.'))
+	private val englishSeparators = LocaleSeparators(decimalSeparator = '.', groupingSeparators = setOf(','))
+
+	@Test
+	fun parsesGermanAmountWithThousands() {
+		val result = AmountParser.parseToApiFormat("1.234,56", germanSeparators)
+		assertEquals("1234.56", result)
+	}
+
+	@Test
+	fun parsesEnglishAmountWithThousands() {
+		val result = AmountParser.parseToApiFormat("1,234.56", englishSeparators)
+		assertEquals("1234.56", result)
+	}
+
+	@Test
+	fun parsesNegativeAmount() {
+		val result = AmountParser.parseToApiFormat("-1.234,56", germanSeparators)
+		assertEquals("-1234.56", result)
+	}
+
+	@Test
+	fun handlesLeadingDecimal() {
+		val result = AmountParser.parseToApiFormat(",5", germanSeparators)
+		assertEquals("0.5", result)
+	}
+
+	@Test
+	fun stripsSpaces() {
+		val result = AmountParser.parseToApiFormat("1 234,56", germanSeparators)
+		assertEquals("1234.56", result)
+	}
+
+	@Test
+	fun leavesInvalidAmountUntouched() {
+		val input = "abc"
+		val result = AmountParser.parseToApiFormat(input, germanSeparators)
+		assertEquals(input, result)
+	}
+
+	@Test
+	fun treatsGermanThousandsWithoutDecimalCorrectly() {
+		val result = AmountParser.parseToApiFormat("1.234", germanSeparators)
+		assertEquals("1234", result)
+	}
+
+	@Test
+	fun acceptsCommaDecimalInEnglishWhenClearIntent() {
+		val result = AmountParser.parseToApiFormat("1,23", englishSeparators)
+		assertEquals("1.23", result)
+	}
+}

--- a/composeApp/src/iosMain/kotlin/de/lehrbaum/firefly/LocaleSeparators.ios.kt
+++ b/composeApp/src/iosMain/kotlin/de/lehrbaum/firefly/LocaleSeparators.ios.kt
@@ -1,0 +1,18 @@
+package de.lehrbaum.firefly
+
+import platform.Foundation.NSNumberFormatter
+import platform.Foundation.NSNumberFormatterDecimalStyle
+
+internal actual fun localeSeparators(): LocaleSeparators {
+	val formatter = NSNumberFormatter().apply {
+		numberStyle = NSNumberFormatterDecimalStyle
+	}
+	val decimalSeparator = formatter.decimalSeparator?.firstOrNull() ?: '.'
+	val groupingSeparators = buildSet {
+		formatter.groupingSeparator?.firstOrNull()?.let { add(it) }
+	}
+	return LocaleSeparators(
+		decimalSeparator = decimalSeparator,
+		groupingSeparators = groupingSeparators,
+	)
+}


### PR DESCRIPTION
## Summary
- add a shared AmountParser that normalizes user-entered amounts to the API format
- provide platform-specific locale separators and use them to strip grouping characters
- parse the amount before creating transactions and cover typical formats with unit tests

## Testing
- ./gradlew --console=plain ktlintFormat
- ./gradlew --console=plain allTests

------
https://chatgpt.com/codex/tasks/task_e_68cdbc9afa5c8332a768ab7fba4ad604