### PR TITLE
Add tag autocomplete field to transaction form

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
@@ -81,6 +81,7 @@ fun App() {
 			AutocompleteTextField(field = viewModel.sourceField, label = "Source account")
 			AutocompleteTextField(field = viewModel.targetField, label = "Target account")
 			AutocompleteTextField(field = viewModel.descriptionField, label = "Description")
+			AutocompleteTextField(field = viewModel.tagField, label = "Tag (optional)")
 			OutlinedTextField(
 				modifier = Modifier.fillMaxWidth(),
 				value = viewModel.amount,

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/MainViewModel.kt
@@ -28,6 +28,7 @@ class MainViewModel(
 	)
 	val targetField = AutocompleteField(scope, autocompleteApi::accounts, Account::name)
 	val descriptionField = AutocompleteField(scope, { q -> autocompleteApi.transactions(q).map { it.description } }, { it })
+	val tagField = AutocompleteField(scope, autocompleteApi::tags, TagSuggestion::name)
 
 	var amount by mutableStateOf("")
 	var errorMessage by mutableStateOf<String?>(null)
@@ -61,6 +62,7 @@ class MainViewModel(
 						descriptionField.selectedText,
 						amount,
 						dateTime.toInstant(TimeZone.currentSystemDefault()),
+						tagField.selectedText.takeIf { it.isNotBlank() },
 					)
 				}
 			} finally {
@@ -95,6 +97,7 @@ class MainViewModel(
 		sourceField.clear()
 		targetField.clear()
 		descriptionField.clear()
+		tagField.clear()
 		amount = ""
 		dateTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
 	}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/TransactionsApi.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/TransactionsApi.kt
@@ -23,6 +23,7 @@ private data class TransactionSplitRequest(
 	@SerialName("source_id") val sourceId: String,
 	@SerialName("destination_id") val destinationId: String? = null,
 	@SerialName("destination_name") val destinationName: String? = null,
+	val tags: List<String>? = null,
 )
 
 @Serializable
@@ -40,6 +41,7 @@ suspend fun createTransaction(
 	description: String,
 	amount: String,
 	date: Instant,
+	tag: String?,
 ) {
 	Napier.i("Creating transaction $description $amount from ${source.name} to ${target?.name ?: targetText}")
 	val type = if (target != null) "transfer" else "withdrawal"
@@ -51,6 +53,7 @@ suspend fun createTransaction(
 		sourceId = source.id,
 		destinationId = target?.id,
 		destinationName = if (target == null) targetText else null,
+		tags = tag?.let(::listOf),
 	)
 	client.post("${BuildKonfig.BASE_URL}/api/v1/transactions") {
 		header(HttpHeaders.Authorization, "Bearer ${BuildKonfig.ACCESS_TOKEN}")


### PR DESCRIPTION
## Summary
- add a tag autocomplete field to the transaction form UI
- fetch tag suggestions from the Firefly autocomplete API and wire them into the view model
- send the optional tag value when creating transactions on the API

## Testing
- ./gradlew ktlintFormat
- ./gradlew checkAgentsEnvironment --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ce3871b4f08332bdbe76ca615c6942