### PR TITLE
Add Compose UI test coverage for text fields and UI test categorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,5 +40,6 @@ use `python openapi_helper.py /v1/accounts --request` to fetch the same data.
 - Add tests for new features whenever possible.
 - Use `kotlin.test` for unit tests in shared code.
 - Use the Compose UI Test toolkit for UI testing.
+- Compose UI tests should not use `waitForIdle`; prefer `waitUntil` or one of its variants.
 - Use `kotlinx.coroutines.test` (e.g. `runTest`) for coroutine-based code.
 - Run `./gradlew checkAgentsEnvironment --console=plain` before committing.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,9 @@ allprojects {
 tasks.register("checkAgentsEnvironment") {
 	group = "verification"
 	description = "Runs all tests that are expected to pass in the agent environment"
+	notCompatibleWithConfigurationCache("Runs unitTestsWithoutUi which configures test filtering at execution time.")
 	dependsOn(
-		":composeApp:testDebugUnitTest",
-		":composeApp:testReleaseUnitTest",
+		":composeApp:unitTestsWithoutUi",
 	)
 	dependsOn("ktlintCheck")
 	dependsOn(subprojects.map { "${it.path}:ktlintCheck" })

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -68,6 +68,7 @@ kotlin {
 		androidUnitTest.dependencies {
 			@OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
 			implementation(compose.uiTest)
+			implementation(libs.robolectric)
 		}
 	}
 }
@@ -125,6 +126,9 @@ tasks.withType<Test>().configureEach {
 	if (shouldSkipUiTests) {
 		useJUnit {
 			excludeCategories("de.lehrbaum.firefly.testing.UiTestCategory")
+		}
+		filter {
+			excludeTestsMatching("*UiTest")
 		}
 	}
 }

--- a/composeApp/src/androidUnitTest/kotlin/de/lehrbaum/firefly/testing/UiTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/de/lehrbaum/firefly/testing/UiTest.kt
@@ -1,0 +1,36 @@
+package de.lehrbaum.firefly.testing
+
+import org.junit.Assume
+import org.junit.experimental.categories.Category
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+interface UiTestCategory
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Category(UiTestCategory::class)
+annotation class UiTest
+
+class UiTestRule : TestRule {
+	override fun apply(base: Statement, description: Description): Statement =
+		object : Statement() {
+			override fun evaluate() {
+				val skipUiTests = java.lang.Boolean.getBoolean(SKIP_UI_TESTS_PROPERTY)
+				if (skipUiTests && description.shouldSkipUiTest()) {
+					Assume.assumeTrue(
+						"Skipping @UiTest ${description.displayName} because $SKIP_UI_TESTS_PROPERTY is true",
+						false,
+					)
+				}
+				base.evaluate()
+			}
+		}
+
+	private fun Description.shouldSkipUiTest(): Boolean = getAnnotation(UiTest::class.java) != null || testClass?.getAnnotation(UiTest::class.java) != null
+
+	private companion object {
+		private const val SKIP_UI_TESTS_PROPERTY = "firefly.skipUiTests"
+	}
+}

--- a/composeApp/src/androidUnitTest/kotlin/de/lehrbaum/firefly/testing/UiTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/de/lehrbaum/firefly/testing/UiTest.kt
@@ -28,7 +28,15 @@ class UiTestRule : TestRule {
 			}
 		}
 
-	private fun Description.shouldSkipUiTest(): Boolean = getAnnotation(UiTest::class.java) != null || testClass?.getAnnotation(UiTest::class.java) != null
+	private fun Description.shouldSkipUiTest(): Boolean {
+		if (getAnnotation(UiTest::class.java) != null) return true
+		if (annotations.any { it.annotationClass == UiTest::class }) return true
+		val resolvedClass = testClass ?: className?.let { runCatching { Class.forName(it) }.getOrNull() }
+		if (resolvedClass?.getAnnotation(UiTest::class.java) != null) return true
+		return annotations.any { annotation ->
+			annotation is Category && annotation.value.any { it == UiTestCategory::class.java }
+		}
+	}
 
 	private companion object {
 		private const val SKIP_UI_TESTS_PROPERTY = "firefly.skipUiTests"

--- a/composeApp/src/androidUnitTest/kotlin/de/lehrbaum/firefly/ui/AppTextFieldsUiTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/de/lehrbaum/firefly/ui/AppTextFieldsUiTest.kt
@@ -7,13 +7,23 @@ import androidx.compose.ui.test.runComposeUiTest
 import de.lehrbaum.firefly.App
 import de.lehrbaum.firefly.testing.UiTest
 import de.lehrbaum.firefly.testing.UiTestRule
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowBuild
 
 @UiTest
+@RunWith(RobolectricTestRunner::class)
 class AppTextFieldsUiTest {
 	@get:Rule(order = 0)
 	val skipIfRequested = UiTestRule()
+
+	@Before
+	fun setUp() {
+		ShadowBuild.setFingerprint("firefly-test")
+	}
 
 	@OptIn(ExperimentalTestApi::class)
 	@Test

--- a/composeApp/src/androidUnitTest/kotlin/de/lehrbaum/firefly/ui/AppTextFieldsUiTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/de/lehrbaum/firefly/ui/AppTextFieldsUiTest.kt
@@ -1,0 +1,36 @@
+package de.lehrbaum.firefly.ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import de.lehrbaum.firefly.App
+import de.lehrbaum.firefly.testing.UiTest
+import de.lehrbaum.firefly.testing.UiTestRule
+import org.junit.Rule
+import org.junit.Test
+
+@UiTest
+class AppTextFieldsUiTest {
+	@get:Rule(order = 0)
+	val skipIfRequested = UiTestRule()
+
+	@OptIn(ExperimentalTestApi::class)
+	@Test
+	fun displaysAllTextFields() {
+		runComposeUiTest {
+			setContent { App() }
+
+			listOf(
+				"Source account",
+				"Target account",
+				"Description",
+				"Tag (optional)",
+				"Amount",
+				"Date & Time",
+			).forEach { label ->
+				onNodeWithText(label, useUnmergedTree = true).assertIsDisplayed()
+			}
+		}
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,8 +17,9 @@ ktor = "3.3.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-collections-immutable = "0.4.0"
 kotlinx-datetime = "0.7.1"
-napier = "2.7.1"
 multiplatform-settings = "1.3.0"
+napier = "2.7.1"
+robolectric = "4.14.1"
 
 
 [libraries]
@@ -41,9 +42,10 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
-napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 multiplatform-settings-noarg = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatform-settings" }
+napier = { module = "io.github.aakira:napier", version.ref = "napier" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- document that Compose UI tests should use waitUntil-style APIs instead of waitForIdle
- add a @UiTest annotation with a helper rule and a Compose UI test ensuring each text field is shown
- configure Gradle tasks to skip @UiTest tests when requested (while keeping `check` running them) and mark the selective tasks as not configuration-cache compatible

## Testing
- ./gradlew ktlintFormat --console=plain
- ./gradlew check --console=plain
- ./gradlew checkAgentsEnvironment --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ce439a3a288332bafb1ecf48448176