### PR TITLE
Add JVM desktop target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ tasks.register("checkAgentsEnvironment") {
 	dependsOn(
 		":composeApp:testDebugUnitTest",
 		":composeApp:testReleaseUnitTest",
+		":composeApp:jvmTest",
 	)
 	dependsOn("ktlintCheck")
 	dependsOn(subprojects.map { "${it.path}:ktlintCheck" })

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -17,6 +17,12 @@ kotlin {
 		}
 	}
 
+	jvm {
+		compilerOptions {
+			jvmTarget.set(JvmTarget.JVM_11)
+		}
+	}
+
 	listOf(
 		iosArm64(),
 		iosSimulatorArm64(),
@@ -51,6 +57,10 @@ kotlin {
 			implementation(libs.multiplatform.settings)
 			implementation(libs.multiplatform.settings.noarg)
 		}
+		jvmMain.dependencies {
+			implementation(compose.desktop.currentOs)
+			implementation(libs.ktor.client.cio)
+		}
 		iosArm64Main.dependencies {
 			implementation(libs.ktor.client.darwin)
 		}
@@ -64,6 +74,12 @@ kotlin {
 			@OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
 			implementation(compose.uiTest)
 		}
+	}
+}
+
+compose.desktop {
+	application {
+		mainClass = "de.lehrbaum.firefly.DesktopAppKt"
 	}
 }
 

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/AmountParser.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/AmountParser.jvm.kt
@@ -1,0 +1,24 @@
+package de.lehrbaum.firefly
+
+import java.math.BigDecimal
+import java.text.DecimalFormat
+import java.text.NumberFormat
+import java.text.ParsePosition
+import java.util.Locale
+
+actual fun parseAmount(input: String, useGermanLocale: Boolean): Result<ParsedAmount> {
+	val trimmedInput = input.trim()
+	if (trimmedInput.isEmpty()) return Result.failure(EmptyAmountException())
+
+	val effectiveLocale = if (useGermanLocale) Locale.GERMANY else Locale.getDefault()
+	val formatter = NumberFormat.getNumberInstance(effectiveLocale) as? DecimalFormat
+		?: return Result.failure(FormatterUnavailableException())
+	formatter.isParseBigDecimal = true
+	val position = ParsePosition(0)
+	val number = formatter.parse(trimmedInput, position) as? BigDecimal
+	return if (number != null && position.index == trimmedInput.length) {
+		Result.success(number.toPlainString())
+	} else {
+		Result.failure(InvalidAmountFormatException(trimmedInput))
+	}
+}

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/DesktopApp.kt
@@ -2,12 +2,12 @@ package de.lehrbaum.firefly
 
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import androidx.compose.ui.window.exitApplication
+import kotlin.system.exitProcess
 
 fun main() {
 	initLogger()
 	application {
-		Window(onCloseRequest = ::exitApplication, title = "Firefly Client") {
+		Window(onCloseRequest = { exitProcess(0) }, title = "Firefly Client") {
 			App()
 		}
 	}

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/DesktopApp.kt
@@ -1,0 +1,14 @@
+package de.lehrbaum.firefly
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.exitApplication
+
+fun main() {
+	initLogger()
+	application {
+		Window(onCloseRequest = ::exitApplication, title = "Firefly Client") {
+			App()
+		}
+	}
+}

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/Logging.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/Logging.jvm.kt
@@ -1,0 +1,8 @@
+package de.lehrbaum.firefly
+
+import io.github.aakira.napier.DebugAntilog
+import io.github.aakira.napier.Napier
+
+actual fun initLogger() {
+	Napier.base(DebugAntilog())
+}

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/firefly/Platform.jvm.kt
@@ -1,0 +1,7 @@
+package de.lehrbaum.firefly
+
+class JvmPlatform : Platform {
+	override val name: String = "JVM ${System.getProperty("os.name") ?: "Unknown OS"}"
+}
+
+actual fun getPlatform(): Platform = JvmPlatform()


### PR DESCRIPTION
## Summary
- enable the JVM target for the Compose app and wire in desktop dependencies
- add a desktop entry point backed by shared UI and logger setup
- provide JVM actual implementations for platform, logging, and amount parsing

## Testing
- ./gradlew ktlintFormat
- ./gradlew checkAgentsEnvironment --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf0ceb8f788332bdd5977a685d89e1