### PR TITLE
Improve network error reporting

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
@@ -48,16 +48,19 @@ private val SIMPLE_FORMAT = LocalDateTime.Format {
 @Composable
 @Preview
 @OptIn(ExperimentalMaterial3Api::class)
-fun App() {
-	MaterialTheme {
-		val client = remember {
+fun App(
+	viewModelFactory: () -> MainViewModel = {
+		MainViewModel(
 			HttpClient {
 				install(ContentNegotiation) {
 					json(Json { ignoreUnknownKeys = true })
 				}
-			}
-		}
-		val viewModel = remember { MainViewModel(client) }
+			},
+		)
+	},
+) {
+	MaterialTheme {
+		val viewModel = remember(viewModelFactory) { viewModelFactory() }
 		val scope = rememberCoroutineScope()
 		val timeZone = remember { TimeZone.currentSystemDefault() }
 		var showDateTimePicker by remember { mutableStateOf(false) }

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/firefly/AppNetworkErrorUiTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/firefly/AppNetworkErrorUiTest.kt
@@ -1,0 +1,94 @@
+package de.lehrbaum.firefly
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import java.awt.GraphicsEnvironment
+import kotlinx.serialization.json.Json
+import org.junit.Assume.assumeFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+
+@OptIn(ExperimentalTestApi::class)
+@Category(UiTest::class)
+class AppNetworkErrorUiTest {
+	private val composeRuleDelegate: ComposeContentTestRule? =
+		if (GraphicsEnvironment.isHeadless()) null else createComposeRule()
+
+	private val composeTestRule: ComposeContentTestRule
+		get() = requireNotNull(composeRuleDelegate) {
+			"Compose tests require a displayable environment"
+		}
+
+	@get:Rule
+	val headlessAwareRule: TestRule = composeRuleDelegate
+		?.let { RuleChain.outerRule(HeadlessSkipRule).around(it) }
+		?: HeadlessSkipRule
+
+	@Test
+	fun showsBackendErrorMessageFromResponseException() {
+		assumeFalse(GraphicsEnvironment.isHeadless())
+		val mockEngine = MockEngine { request ->
+			val path = request.url.encodedPath
+			when {
+				path == "/api/v1/transactions" ->
+					respond(
+						content = "Backend rejected transaction",
+						status = HttpStatusCode.BadRequest,
+						headers = headersOf(HttpHeaders.ContentType, "text/plain"),
+					)
+				path in setOf(
+					"/api/v1/autocomplete/accounts",
+					"/api/v1/autocomplete/transactions",
+					"/api/v1/autocomplete/tags",
+				) ->
+					respond(
+						content = "[]",
+						headers = headersOf(HttpHeaders.ContentType, "application/json"),
+					)
+				else -> error("Unhandled ${'$'}{request.url}")
+			}
+		}
+		val httpClient = HttpClient(mockEngine) {
+			install(ContentNegotiation) {
+				json(Json { ignoreUnknownKeys = true })
+			}
+		}
+		val viewModel = MainViewModel(
+			client = httpClient,
+			autocompleteApi = AutocompleteApi(httpClient),
+		)
+		val sourceAccount = Account(id = "1", name = "Checking")
+		viewModel.sourceField.select(sourceAccount)
+		viewModel.targetField.onTextChange("Savings")
+		viewModel.descriptionField.onTextChange("Groceries")
+		viewModel.amount = "10.00"
+
+		composeTestRule.setContent {
+			App(viewModelFactory = { viewModel })
+		}
+
+		composeTestRule.onNodeWithText("Save").performClick()
+
+		val expectedMessage =
+			"Request to https://firefly.lehrenko.de/api/v1/transactions failed (400 Bad Request): Backend rejected transaction"
+		composeTestRule.waitUntilAtLeastOneExists(
+			hasText(expectedMessage),
+		)
+	}
+}

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/firefly/AppTextFieldsUiTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/firefly/AppTextFieldsUiTest.kt
@@ -12,8 +12,6 @@ import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
-import org.junit.runner.Description
-import org.junit.runners.model.Statement
 
 @OptIn(ExperimentalTestApi::class)
 @Category(UiTest::class)
@@ -46,15 +44,5 @@ class AppTextFieldsUiTest {
 		).forEach { label ->
 			composeTestRule.waitUntilAtLeastOneExists(hasText(label))
 		}
-	}
-
-	private object HeadlessSkipRule : TestRule {
-		override fun apply(base: Statement, description: Description): Statement =
-			object : Statement() {
-				override fun evaluate() {
-					assumeFalse(GraphicsEnvironment.isHeadless())
-					base.evaluate()
-				}
-			}
 	}
 }

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/firefly/HeadlessSkipRule.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/firefly/HeadlessSkipRule.kt
@@ -1,0 +1,17 @@
+package de.lehrbaum.firefly
+
+import java.awt.GraphicsEnvironment
+import org.junit.Assume.assumeFalse
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+object HeadlessSkipRule : TestRule {
+	override fun apply(base: Statement, description: Description): Statement =
+		object : Statement() {
+			override fun evaluate() {
+				assumeFalse(GraphicsEnvironment.isHeadless())
+				base.evaluate()
+			}
+		}
+}


### PR DESCRIPTION
## Summary
- capture status, URL, and response body from ResponseException to show backend feedback in the error banner
- preserve connection-specific handling for I/O failures while clearing errors on successful calls

## Testing
- ./gradlew checkAgentsEnvironment --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d415ecda248332ac93ad248c27b4fa