### PR TITLE
Add save outcome banners

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
@@ -71,15 +71,22 @@ fun App(
 				.fillMaxSize()
 				.padding(16.dp),
 		) {
-			if (viewModel.errorMessage != null) {
+			viewModel.bannerState?.let { banner ->
+				val (containerColor, contentColor) = when (banner.type) {
+					BannerType.Success ->
+						MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
+					BannerType.Error ->
+						MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
+				}
 				Text(
-					viewModel.errorMessage!!,
+					banner.message,
 					modifier = Modifier
 						.fillMaxWidth()
-						.background(MaterialTheme.colorScheme.errorContainer)
+						.background(containerColor)
 						.padding(8.dp),
-					color = MaterialTheme.colorScheme.onErrorContainer,
+					color = contentColor,
 				)
+				Spacer(Modifier.size(8.dp))
 			}
 			AutocompleteTextField(field = viewModel.sourceField, label = "Source account")
 			AutocompleteTextField(field = viewModel.targetField, label = "Target account")

--- a/reassignGooglePayTransactions.main.kts
+++ b/reassignGooglePayTransactions.main.kts
@@ -4,6 +4,7 @@
 @file:DependsOn("io.ktor:ktor-client-content-negotiation-jvm:3.3.0")
 @file:DependsOn("io.ktor:ktor-serialization-kotlinx-json-jvm:3.3.0")
 @file:DependsOn("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.9.0")
+@file:Suppress("ktlint:standard:property-naming")
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO


### PR DESCRIPTION
## Summary
- show a reusable banner in the form for save outcomes using success and error colors
- manage banner state inside `MainViewModel`, reporting success, validation, and network failures
- suppress ktlint property naming warnings in the Kotlin script so `ktlintFormat` can run cleanly

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d98a1442608332bca824719f30ee15