### PR TITLE
Add validation errors for missing required fields

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/App.kt
@@ -88,9 +88,21 @@ fun App(
 				)
 				Spacer(Modifier.size(8.dp))
 			}
-			AutocompleteTextField(field = viewModel.sourceField, label = "Source account")
+			AutocompleteTextField(
+				field = viewModel.sourceField,
+				label = "Source account",
+				error = viewModel.sourceFieldError,
+				onTextChange = viewModel::onSourceTextChange,
+				onSuggestionSelected = viewModel::onSourceSuggestionSelected,
+			)
 			AutocompleteTextField(field = viewModel.targetField, label = "Target account")
-			AutocompleteTextField(field = viewModel.descriptionField, label = "Description")
+			AutocompleteTextField(
+				field = viewModel.descriptionField,
+				label = "Description",
+				error = viewModel.descriptionFieldError,
+				onTextChange = viewModel::onDescriptionTextChange,
+				onSuggestionSelected = viewModel::onDescriptionSuggestionSelected,
+			)
 			AutocompleteTextField(field = viewModel.tagField, label = "Tag (optional)")
 			OutlinedTextField(
 				modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/AutocompleteTextField.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/AutocompleteTextField.kt
@@ -17,7 +17,13 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun <T> AutocompleteTextField(field: AutocompleteField<T>, label: String) {
+fun <T> AutocompleteTextField(
+	field: AutocompleteField<T>,
+	label: String,
+	error: String? = null,
+	onTextChange: (String) -> Unit = field::onTextChange,
+	onSuggestionSelected: (T) -> Unit = field::select,
+) {
 	val focusRequester = remember { FocusRequester() }
 	ExposedDropdownMenuBox(
 		expanded = field.expanded,
@@ -29,8 +35,12 @@ fun <T> AutocompleteTextField(field: AutocompleteField<T>, label: String) {
 		OutlinedTextField(
 			modifier = Modifier.fillMaxWidth().focusRequester(focusRequester).menuAnchor(MenuAnchorType.PrimaryEditable),
 			value = field.text,
-			onValueChange = field::onTextChange,
+			onValueChange = onTextChange,
 			label = { Text(label) },
+			isError = error != null,
+			supportingText = error?.let { message ->
+				{ Text(message) }
+			},
 		)
 		ExposedDropdownMenu(
 			expanded = field.expanded,
@@ -38,7 +48,7 @@ fun <T> AutocompleteTextField(field: AutocompleteField<T>, label: String) {
 		) {
 			field.suggestions.forEach { suggestion ->
 				DropdownMenuItem(
-					onClick = { field.select(suggestion) },
+					onClick = { onSuggestionSelected(suggestion) },
 					text = { Text(field.itemText(suggestion)) },
 				)
 			}


### PR DESCRIPTION
## Summary
- surface field-level validation for the source account and description inputs
- show banner feedback and field errors when either required field is empty while saving
- keep error state cleared as the user edits the form

## Testing
- ./gradlew ktlintFormat
- ./gradlew checkAgentsEnvironment --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dc38f5c0988332befaf86ccff296a3