### PR TITLE
Show loading indicator for autocomplete suggestions

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/AutocompleteField.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/AutocompleteField.kt
@@ -32,6 +32,8 @@ class AutocompleteField<T>(
 	var selected by mutableStateOf<T?>(null)
 	var suggestions by mutableStateOf<PersistentList<T>>(persistentListOf())
 		private set
+	var isLoading by mutableStateOf(false)
+		private set
 
 	val selectedText: String
 		get() = selected?.let(textOf) ?: text
@@ -41,8 +43,13 @@ class AutocompleteField<T>(
 	init {
 		scope.launch {
 			query.debounce(debounce).collectLatest { q ->
-				suggestions = fetcher(q).toPersistentList()
-				selected = suggestions.firstOrNull { textOf(it) == text }
+				isLoading = true
+				try {
+					suggestions = fetcher(q).toPersistentList()
+					selected = suggestions.firstOrNull { textOf(it) == text }
+				} finally {
+					isLoading = false
+				}
 			}
 		}
 	}
@@ -65,6 +72,7 @@ class AutocompleteField<T>(
 		expanded = false
 		selected = null
 		suggestions = persistentListOf()
+		isLoading = false
 		query.value = ""
 	}
 

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/AutocompleteTextField.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/firefly/AutocompleteTextField.kt
@@ -1,6 +1,8 @@
 package de.lehrbaum.firefly
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -13,6 +15,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -42,6 +45,19 @@ fun <T> AutocompleteTextField(
 			expanded = field.expanded,
 			onDismissRequest = { field.expanded = false },
 		) {
+			if (field.isLoading) {
+				DropdownMenuItem(
+					onClick = {},
+					enabled = false,
+					leadingIcon = {
+						CircularProgressIndicator(
+							modifier = Modifier.size(16.dp),
+							strokeWidth = 2.dp,
+						)
+					},
+					text = { Text("Loading…") },
+				)
+			}
 			field.suggestions.forEach { suggestion ->
 				DropdownMenuItem(
 					onClick = { field.select(suggestion) },


### PR DESCRIPTION
## Summary
- track a loading flag while fetching autocomplete suggestions
- render a disabled loading indicator entry at the top of the dropdown while results are loading

## Testing
- ./gradlew checkAgentsEnvironment --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ded72146ec83329a9ef10874fcabb8